### PR TITLE
some changes

### DIFF
--- a/lua/ge/extensions/gameplay/events/freeroam/activeAssets.lua
+++ b/lua/ge/extensions/gameplay/events/freeroam/activeAssets.lua
@@ -1,7 +1,7 @@
 local M = {}
 
-local maxAssets = 6
-local maxActiveAssets = 2
+local maxAssets = 200
+local maxActiveAssets = 200
 local ActiveAssets = {}
 ActiveAssets.__index = ActiveAssets
 

--- a/lua/ge/extensions/gameplay/events/freeroam/activeAssets.lua
+++ b/lua/ge/extensions/gameplay/events/freeroam/activeAssets.lua
@@ -1,7 +1,7 @@
 local M = {}
 
-local maxAssets = 200
-local maxActiveAssets = 200
+local maxAssets = 100
+local maxActiveAssets = 100
 local ActiveAssets = {}
 ActiveAssets.__index = ActiveAssets
 
@@ -66,13 +66,12 @@ function ActiveAssets:displayAssets(data, isAltRoute)
     local newAssets = {}
 
     for i = 0, maxAssets - 1 do
-
         local assetName
         if isAltRoute then
-            -- New naming for the alternate route
+            -- New naming for the altRoute
             assetName = "alt_asset" .. i
         else
-            -- Original naming for the main route
+            -- naming for the main route
             assetName = triggerName .. "asset" .. i
         end
 

--- a/lua/ge/extensions/gameplay/events/freeroam/activeAssets.lua
+++ b/lua/ge/extensions/gameplay/events/freeroam/activeAssets.lua
@@ -61,12 +61,21 @@ function ActiveAssets:getOldestAssetList()
     return self.assets[1]
 end
 
-function ActiveAssets:displayAssets(data)
+function ActiveAssets:displayAssets(data, isAltRoute)
     local triggerName = data.triggerName
     local newAssets = {}
 
     for i = 0, maxAssets - 1 do
-        local assetName = triggerName .. "asset" .. i
+
+        local assetName
+        if isAltRoute then
+            -- New naming for the alternate route
+            assetName = "alt_asset" .. i
+        else
+            -- Original naming for the main route
+            assetName = triggerName .. "asset" .. i
+        end
+
         local asset = scenetree.findObject(assetName)
         if asset then
             asset:setHidden(false)

--- a/lua/ge/extensions/gameplay/events/freeroam/checkpointManager.lua
+++ b/lua/ge/extensions/gameplay/events/freeroam/checkpointManager.lua
@@ -151,22 +151,23 @@ local function resetActiveCheckpoints()
 end
 
 local function enableCheckpoint(checkpointIndex, alt)
-
     resetActiveCheckpoints()
 
     local expectedIndex
 
-    
+    -- This logic cleanly separates the two states.
     if mAltRoute then
-        -- choice 1: alternate route.
+        -- SCENARIO 1: We are currently on an alternate route.
         expectedIndex = checkpointIndex + 1
         
+        -- The next checkpoint to display MUST be blue.
         local currentCp = altCheckpoints and altCheckpoints[expectedIndex]
         if currentCp then
             if not currentCp.marker then createCheckpointMarker(expectedIndex, true) end
             currentCp.marker.instanceColor = ColorF(0, 0, 1, 0.7):asLinear4F() -- Blue
         end
 
+        -- The preview checkpoint (red) must also be from the alt route.
         local previewIndex = expectedIndex + 1
         local previewCp = altCheckpoints and altCheckpoints[previewIndex]
         if previewCp then
@@ -175,15 +176,17 @@ local function enableCheckpoint(checkpointIndex, alt)
         end
 
     else
-        -- choice 2: main route.
+        -- SCENARIO 2: We are currently on the main route.
         expectedIndex = checkpointIndex + 1
 
+        -- The next checkpoint to display MUST be green.
         local currentCp = checkpoints and checkpoints[expectedIndex]
         if currentCp then
             if not currentCp.marker then createCheckpointMarker(expectedIndex, false) end
             currentCp.marker.instanceColor = ColorF(0, 1, 0, 0.7):asLinear4F() -- Green
         end
 
+        -- The preview checkpoint (red) must also be from the main route.
         local previewIndex = expectedIndex + 1
         local previewCp = checkpoints and checkpoints[previewIndex]
         if previewCp then
@@ -191,6 +194,7 @@ local function enableCheckpoint(checkpointIndex, alt)
             previewCp.marker.instanceColor = ColorF(1, 0, 0, 0.5):asLinear4F() -- Red
         end
 
+        -- BACKWARDS COMPATIBILITY: If this is a classic race, ALSO show the first blue checkpoint.
         if race and race.altRoute and not race.forks and #altCheckpoints > 0 then
             local altStartCp = altCheckpoints[1]
             if altStartCp then
@@ -214,14 +218,14 @@ local function enableForkCheckpoints(mainIndex, altIndex, raceData)
             mainCp = createCheckpointMarker(mainIndex, false)
         end
         -- Color for a choice, e.g., blue
-        mainCp.marker.instanceColor = ColorF(0, 1, 0, 0.7):asLinear4F() 
+        mainCp.marker.instanceColor = ColorF(0, 0, 1, 0.7):asLinear4F() 
     end
 
     if altCp then
         if not altCp.marker then
             altCp = createCheckpointMarker(altIndex, true)
         end
-        -- Color for b choice, e.g., blue
+        -- Color for a choice, e.g., blue
         altCp.marker.instanceColor = ColorF(0, 0, 1, 0.7):asLinear4F()
     end
 
@@ -299,7 +303,6 @@ local function calculateTotalCheckpoints(raceData)
 end
 
 local function setAltRoute(altRoute)
-    mAltRoute = altRoute
 end
 
 local function setRace(inputRace, inputRaceName)

--- a/lua/ge/extensions/gameplay/events/freeroam/pits.lua
+++ b/lua/ge/extensions/gameplay/events/freeroam/pits.lua
@@ -3,15 +3,14 @@ local M = {}
 local activeSpeedLimit = nil
 local limitActive = false
 local applyingLimit = false
-local lastThrottleState = 0 -- Store the last known throttle state
-local forcingStop = false -- Flag to indicate if we're in "stop first" mode
-local limiterMode = "cruise" -- New variable to track which mode we're in
+local lastThrottleState = 0
+local forcingStop = false
+local limiterMode = "cruise"
 
 -- Function to get throttle input from vehicle
 local function requestThrottleInput()
   local veh = be:getPlayerVehicle(0)
   if not veh then return end
-  
   veh:queueLuaCommand([[
     local throttleInput = input.lastInputs["local"].throttle or 0
     obj:queueGameEngineLua('gameplay_events_freeroam_pits.receiveThrottleInput(' .. throttleInput .. ')')
@@ -23,105 +22,49 @@ local function receiveThrottleInput(value)
   lastThrottleState = value
 end
 
--- Function to apply speed limit to the vehicle
 local function applySpeedLimit(dt)
   if not activeSpeedLimit or not limitActive then return end
-  
-  -- Get the current player vehicle
   local veh = be:getPlayerVehicle(0)
   if not veh then return end
-  
-  -- Get current speed in m/s
   local vel = veh:getVelocity():length()
-  
-  -- Check if we're in "force stop" mode
   if forcingStop then
-    -- Apply full brakes until vehicle is almost stopped
     veh:queueLuaCommand("input.event('throttle', 0, 1, nil, nil, nil, 'code')")
     veh:queueLuaCommand("input.event('brake', 0.85, 1, nil, nil, nil, 'code')")
-    
-    -- Check if we've reached near-stop condition
     if vel < 1.0 then
-      -- Vehicle is almost stopped, switch to regular limit mode
       forcingStop = false
       applyingLimit = false
-      log('I', 'pits', 'Vehicle stopped and repaired, now applying regular speed limit of ' .. 
-          math.floor(activeSpeedLimit * 3.6) .. ' km/h')
       if not career_career then
-        veh:queueLuaCommand([[
-          recovery.startRecovering()
-          recovery.stopRecovering()
-        ]])
+        veh:queueLuaCommand([[ recovery.startRecovering() recovery.stopRecovering() ]])
       end
-      veh:queueLuaCommand([[
-        input.event('brake', 0.5, 1, nil, nil, nil, 'code')
-        input.event('throttle', 0.5, 1, nil, nil, nil, 'code')
-        input.event('brake', 0, 1, nil, nil, nil, 'code')
-        input.event('throttle', 0, 1, nil, nil, nil, 'code')
-      ]])
+      veh:queueLuaCommand([[ input.event('brake', 0.5, 1) input.event('throttle', 0.5, 1) input.event('brake', 0, 1) input.event('throttle', 0, 1) ]])
     end
-    
     return
   end
-  
-  -- Regular speed limiting logic (unchanged)
-  
-  -- Request the throttle input (will be available on next frame)
   requestThrottleInput()
-  
-  -- Check if we're currently applying a limit
   local wasLimiting = applyingLimit
-  
-  -- Calculate how close we are to the speed limit (0.0 = at limit, 1.0 = far below)
   local speedRatio = 1.0 - (vel / activeSpeedLimit)
-  
-  -- Speed limit behavior
   if vel >= activeSpeedLimit then
-    -- We're at or above the speed limit - always apply brakes
-    
-    -- Calculate how much we're over the limit for proportional braking
     local overSpeed = vel - activeSpeedLimit
     local brakeAmount = math.min(1.0, overSpeed * 0.5)
-    
-    -- Always cut throttle and apply brakes when over the limit
     veh:queueLuaCommand("input.event('throttle', 0, 1, nil, nil, nil, 'code')")
     veh:queueLuaCommand("input.event('brake', " .. brakeAmount .. ", 1, nil, nil, nil, 'code')")
-    
     applyingLimit = true
   else
-    -- We're below the speed limit
-    
-    -- If the user is holding throttle, help them maintain the speed limit
     if lastThrottleState > 0.01 then
-      -- Calculate how much we're under the limit
       local underSpeed = activeSpeedLimit - vel
-      
-      -- Calculate proximity factor (becomes smaller as we approach the limit)
       local proximityFactor = math.min(1.0, speedRatio * 2.0)
-      
-      -- Apply throttle more conservatively as we approach the limit
       local throttleAmount
-      
       if speedRatio < 0.05 then
-        -- Within 5% of the limit, be very conservative
         throttleAmount = math.min(lastThrottleState, 0.20)
       elseif speedRatio < 0.15 then
-        -- Within 15% of the limit, be somewhat conservative
         throttleAmount = math.min(lastThrottleState, lastThrottleState * proximityFactor + 0.1 * underSpeed)
       else
-        -- Far from the limit, apply more throttle but still avoid overshooting
         throttleAmount = math.min(1.0, lastThrottleState + (underSpeed * 0.1 * proximityFactor))
       end
-      
-      -- Apply the calculated throttle to maintain speed
       veh:queueLuaCommand("input.event('throttle', " .. throttleAmount .. ", 1, nil, nil, nil, 'code')")
-      
-      -- Make sure we're not braking
       veh:queueLuaCommand("input.event('brake', 0, 1)")
-      
       applyingLimit = true
     else
-      -- User isn't applying throttle, let them control the vehicle
       if wasLimiting then
         applyingLimit = false
       end
@@ -159,6 +102,16 @@ local function applyGovernorLimit(dt)
   veh:queueLuaCommand("input.event('throttle', " .. finalThrottle .. ", 1, nil, nil, nil, 'code')")
 end
 
+local function onUpdate(dt)
+  if activeSpeedLimit and limitActive then
+    if limiterMode == "governor" then
+      applyGovernorLimit(dt)
+    else -- Default to cruise control
+      applySpeedLimit(dt)
+    end
+  end
+end
+
 local function _baseSetLimit(limit, unit)
   if type(limit) ~= "number" or limit <= 0 then
     activeSpeedLimit, limitActive, applyingLimit, forcingStop = nil, false, false, false
@@ -175,6 +128,7 @@ local function _baseSetLimit(limit, unit)
   return true
 end
 
+-- Original functions now set the mode to "cruise"
 local function setSpeedLimit(limit, unit)
   if _baseSetLimit(limit, unit) then
     limiterMode = "cruise"
@@ -182,7 +136,6 @@ local function setSpeedLimit(limit, unit)
   end
 end
 
--- Function to first stop the vehicle completely, then apply speed limit
 local function stopThenLimit(limit, unit)
   if setSpeedLimit(limit, unit) then
     forcingStop = true
@@ -190,6 +143,7 @@ local function stopThenLimit(limit, unit)
   end
 end
 
+-- New functions to set the mode to "governor"
 local function setGovernorLimit(limit, unit)
   if _baseSetLimit(limit, unit) then
     limiterMode = "governor"
@@ -204,7 +158,7 @@ local function stopThenGovernor(limit, unit)
   end
 end
 
--- Function to toggle the speed limit on/off without changing the value
+-- Other public functions
 local function toggleSpeedLimit()
   limitActive = not limitActive
   if not limitActive then
@@ -218,25 +172,16 @@ local function clearSpeedLimit()
   activeSpeedLimit, limitActive, applyingLimit, forcingStop, limiterMode = nil, false, false, false, "cruise"
 end
 
--- Update function to be called in the vehicle update loop
-local function onUpdate(dt)
-  if activeSpeedLimit and limitActive then
-    if limiterMode == "governor" then
-      applyGovernorLimit(dt)
-    else -- Default to cruise control
-      applySpeedLimit(dt)
-    end
-  end
-end
-
 -- Register this module to receive updates
 M.onUpdate = onUpdate
-M.setSpeedLimit = setSpeedLimit
-M.toggleSpeedLimit = toggleSpeedLimit
-M.stopThenLimit = stopThenLimit
 M.receiveThrottleInput = receiveThrottleInput
 M.clearSpeedLimit = clearSpeedLimit
+M.toggleSpeedLimit = toggleSpeedLimit
 
+-- Expose both sets of functions
+M.setSpeedLimit = setSpeedLimit
+M.stopThenLimit = stopThenLimit
 M.setGovernorLimit = setGovernorLimit
 M.stopThenGovernor = stopThenGovernor
+
 return M

--- a/lua/ge/extensions/gameplay/events/freeroam/utils.lua
+++ b/lua/ge/extensions/gameplay/events/freeroam/utils.lua
@@ -378,8 +378,9 @@ local function displayStagedMessage(vehId, raceName, getMessage)
     elseif bestTime > targetTime then
       if careerMode then
         local adjustedBaseReward = raceReward(targetTime, reward, targetTime, raceData and raceData.type or nil)
-        return string.format("%sYour Best Time: %s | Target Time: %s\n(Achieve target to earn a reward of $%.2f)",
-          label, formatTime(bestTime), formatTime(targetTime), adjustedBaseReward)
+        return string.format(
+          "%sYour Best Time: %s | Target Time: %s\n(Achieve target to earn a reward of $%.2f)", label,
+          formatTime(bestTime), formatTime(targetTime), adjustedBaseReward)
       else
         return string.format("%sYour Best Time: %s | Target Time: %s", label, formatTime(bestTime),
           formatTime(targetTime))
@@ -448,16 +449,16 @@ local function displayStagedMessage(vehId, raceName, getMessage)
           "Your Best Speed: %.2f mph | Target Speed: %.2f mph\nYour Best Time: %s\n(Improve to earn at least $%.2f)",
           bestSpeed, targetSpeed, formatTime(bestTime), adjustedReward)
       else
-        message = message ..
-                    string.format("Your Best Speed: %.2f mph | Target Speed: %.2f mph\nYour Best Time: %s", bestSpeed,
-            targetSpeed, formatTime(bestTime))
+        message = message .. string.format(
+          "Your Best Speed: %.2f mph | Target Speed: %.2f mph\nYour Best Time: %s",
+          bestSpeed, targetSpeed, formatTime(bestTime))
       end
     else
       if careerMode then
         local adjustedReward = topSpeedReward(targetSpeed, race.reward, targetSpeed, race.type)
-        message = message ..
-                    string.format("Target Speed: %.2f mph\n(Achieve this to earn a reward of $%.2f and 1 Bonus Star)",
-            targetSpeed, adjustedReward)
+        message = message .. string.format(
+          "Target Speed: %.2f mph\n(Achieve this to earn a reward of $%.2f and 1 Bonus Star)",
+          targetSpeed, adjustedReward)
       else
         message = message .. string.format("Target Speed: %.2f mph", targetSpeed)
       end

--- a/lua/ge/extensions/gameplay/events/freeroamEvents.lua
+++ b/lua/ge/extensions/gameplay/events/freeroamEvents.lua
@@ -494,6 +494,7 @@ local function exitRace(isCompletion, customMessage, raceData, subjectID)
             -- Race cancellation logic
             local message = customMessage or "You exited the race zone, Race cancelled"
             utils.displayMessage(message, 3)
+            staged = nil
         end
 
         utils.setActiveLight(raceName, "red")
@@ -883,6 +884,7 @@ local function onBeamNGTrigger(data)
             rollingStartArmed = true
             pits.clearSpeedLimit()
             utils.displayMessage("GO! GO! GO!", 3)
+            staged = nil
         end
         
     elseif triggerType == "pits" then

--- a/lua/ge/extensions/gameplay/events/freeroamEvents.lua
+++ b/lua/ge/extensions/gameplay/events/freeroamEvents.lua
@@ -867,6 +867,7 @@ local function onBeamNGTrigger(data)
     elseif triggerType == "finish" then
         if event == "enter" and mActiveRace == raceName then
             exitRace(true, nil, races[raceName], data.subjectID)
+            staged = nil
         end
 
         elseif triggerType == "pacezone" then
@@ -884,7 +885,6 @@ local function onBeamNGTrigger(data)
             rollingStartArmed = true
             pits.clearSpeedLimit()
             utils.displayMessage("GO! GO! GO!", 3)
-            staged = nil
         end
         
     elseif triggerType == "pits" then

--- a/lua/ge/extensions/gameplay/events/freeroamEvents.lua
+++ b/lua/ge/extensions/gameplay/events/freeroamEvents.lua
@@ -726,21 +726,7 @@ local function onBeamNGTrigger(data)
             end
             invalidLap = false
         elseif event == "enter" and staged == raceName then
-            -- DEBUG BLOCK STARTS HERE --
-            print("--- Start Trigger Check for race: " .. tostring(raceName) .. " ---")
-            local isRollingStartRace = races[raceName] and races[raceName].rollingStart ~= nil
-            print("Is this a rolling start race? " .. tostring(isRollingStartRace))
-            print("RAW VALUE of .rollingStart key is: >" .. tostring(races[raceName].rollingStart) .. "<")
-            print("Is the rollingStartArmed flag TRUE? " .. tostring(rollingStartArmed))
 
-            local condition1 = not isRollingStartRace
-            local condition2 = rollingStartArmed
-            print("Condition 1 (NOT a rolling start race) is: " .. tostring(condition1))
-            print("Condition 2 (rolling start IS armed) is: " .. tostring(condition2))
-
-            local finalResult = condition1 or condition2
-            print("FINAL RESULT (Condition 1 OR Condition 2) is: " .. tostring(finalResult))
-            -- DEBUG BLOCK ENDS HERE --
 
             if finalResult then
                 if races[raceName] and races[raceName].rollingStart then


### PR DESCRIPTION
added a new track split "system"

`"forks": [
        {
            "atMainIndex": 2,
            "mainChoiceIndex": 3,
            "altChoiceIndex": 1
        }
        ],`
        
u specify after which checkpoint of the main track it splits and then choice A (mainChoiceIndex) Which is a checkpoint on the main track and B (altChoiceIndex) which is a checkpoint on the altRoute. didnt touch the merge checkpoints logic to not break already existing races that use it. and it still uses altRoute logic to get the races info and the checkpointRoad and Indexs
        
also added roll-race-like system which uses another lua Trigger called paceZone that comes between the stage and the start triggers. can be used with a soft speed limiter that limits the throttle when u get up to the specified speed the when u reach it without automating the throttle inputs also works with both kph and mph 


works by adding this to ur race :

`"rollingStart":{
        "paceSpeed": 0,
        "speedUnit": "KPH"
      },`
      
i might forget small edits but for now it does work well

also added different naming to altRoute assets that becomes visible if u chose the altRoute but it still needs a bit of work